### PR TITLE
feat: mock UI testing system with 5 scenario fixtures

### DIFF
--- a/e2e/mock-ui.spec.ts
+++ b/e2e/mock-ui.spec.ts
@@ -1,0 +1,364 @@
+import { expect, test } from "@playwright/test";
+
+const SCENARIOS = ["Basic Chat", "Tool Calls", "Thinking Blocks", "Streaming Slow", "Error States"];
+
+async function switchScenario(page: import("@playwright/test").Page, name: string) {
+  const scenarioBtn = page.locator(`button:has-text("${name}")`);
+  if (!(await scenarioBtn.isVisible())) {
+    await page.locator("text=Mock").first().click();
+    await page.waitForTimeout(100);
+  }
+  await scenarioBtn.click();
+
+  // Wait for the scenario switch to reset messages
+  await page.waitForTimeout(300);
+}
+
+async function waitForTurnCount(
+  page: import("@playwright/test").Page,
+  selector: string,
+  minCount: number,
+  timeout = 30_000,
+) {
+  await page.waitForFunction(
+    ({ sel, min }) => document.querySelectorAll(sel).length >= min,
+    { sel: selector, min: minCount },
+    { timeout },
+  );
+}
+
+async function waitForNoWorkingIndicator(page: import("@playwright/test").Page, timeout = 30_000) {
+  await page.waitForFunction(() => !document.querySelector(".working-indicator"), {}, { timeout });
+}
+
+// -- Page Load --
+
+test.describe("Mock UI - Page Load", () => {
+  test("renders the app shell without Office.js errors", async ({ page }) => {
+    const consoleErrors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error") consoleErrors.push(msg.text());
+    });
+
+    await page.goto("/");
+    await expect(page.locator(".app-title")).toHaveText("OpenExcel");
+    await expect(page.locator(".pill")).toHaveText("mock");
+
+    await page.waitForTimeout(2000);
+
+    const officeErrors = consoleErrors.filter(
+      (e) => e.includes("Office") || e.includes("office.js"),
+    );
+    expect(officeErrors).toHaveLength(0);
+  });
+
+  test("shows scenario picker overlay", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.locator("text=Mock").first()).toBeVisible();
+  });
+});
+
+// -- Basic Chat --
+// Default scenario, auto-plays 3 turns → 3 user + 3 assistant messages
+
+test.describe("Mock UI - Basic Chat Scenario", () => {
+  test("renders text messages with markdown", async ({ page }) => {
+    await page.goto("/");
+
+    // Basic Chat auto-plays. Wait for all 3 assistant messages.
+    await waitForTurnCount(page, ".msg-assistant", 3, 20_000);
+    await waitForNoWorkingIndicator(page);
+
+    await expect(page.locator(".msg-user").first()).toBeVisible();
+
+    const assistantContent = page.locator(".msg-text").first();
+    await expect(assistantContent).toBeVisible();
+
+    const htmlContent = await assistantContent.innerHTML();
+    expect(
+      htmlContent.includes("<strong>") ||
+        htmlContent.includes("<li>") ||
+        htmlContent.includes("<code>"),
+    ).toBe(true);
+  });
+
+  test("shows turn footer with timing and tokens", async ({ page }) => {
+    await page.goto("/");
+    await waitForTurnCount(page, ".msg-assistant", 3, 20_000);
+    await waitForNoWorkingIndicator(page, 25_000);
+
+    const turnFooter = page.locator(".turn-footer");
+    await expect(turnFooter).toBeVisible({ timeout: 5_000 });
+  });
+});
+
+// -- Tool Calls --
+// 4 turns, each with tool calls. Turn 3 has an error. Turn 4 has 2 tool calls.
+// Expected: ~8 assistant messages total (2 per turn: one with tools, one with text)
+
+test.describe("Mock UI - Tool Calls Scenario", () => {
+  test("renders tool call cards with success and error states", async ({ page }) => {
+    await page.goto("/");
+    await switchScenario(page, "Tool Calls");
+    await waitForTurnCount(page, ".tool-card", 1, 15_000);
+    await waitForTurnCount(page, ".msg-assistant", 6, 30_000);
+    await waitForNoWorkingIndicator(page);
+
+    const doneCards = page.locator(".tool-card-done");
+    await expect(doneCards.first()).toBeVisible();
+
+    const errorCards = page.locator(".tool-card-error");
+    await expect(errorCards.first()).toBeVisible();
+  });
+
+  test("tool cards are expandable", async ({ page }) => {
+    await page.goto("/");
+    await switchScenario(page, "Tool Calls");
+    await waitForTurnCount(page, ".tool-card", 1, 15_000);
+
+    // Collapse the picker first so it doesn't intercept clicks
+    const pickerHeader = page.locator("text=Mock").first();
+    if (await page.locator(`button:has-text("${SCENARIOS[0]}")`).isVisible()) {
+      await pickerHeader.click();
+      await page.waitForTimeout(100);
+    }
+
+    const toolHeader = page.locator(".tool-card-header").first();
+    await toolHeader.click();
+
+    const inputSection = page.locator(".tool-card-section").first();
+    await expect(inputSection).toBeVisible();
+  });
+
+  test("tool groups collapse multiple tool calls in one message", async ({ page }) => {
+    await page.goto("/");
+    await switchScenario(page, "Tool Calls");
+    // Wait for all turns to complete - 4 turns produce 8 assistant messages
+    await waitForTurnCount(page, ".msg-assistant", 8, 40_000);
+    await waitForNoWorkingIndicator(page);
+
+    // Turn 4 has an assistant message with 2 tool calls, which should render
+    // as a .tool-group via groupMessageParts. Also, the consecutive tool-only
+    // assistant messages across turns might produce cross-message tool-groups.
+    // Wait for at least one tool-group to appear.
+    await page.waitForFunction(
+      () => document.querySelectorAll(".tool-group").length > 0,
+      {},
+      { timeout: 5_000 },
+    );
+
+    const toolGroups = page.locator(".tool-group");
+    const groupCount = await toolGroups.count();
+    expect(groupCount).toBeGreaterThan(0);
+  });
+});
+
+// -- Thinking --
+// 2 turns with thinking blocks, tool calls, and text
+
+test.describe("Mock UI - Thinking Scenario", () => {
+  test("renders thinking blocks", async ({ page }) => {
+    await page.goto("/");
+    await switchScenario(page, "Thinking Blocks");
+    await waitForTurnCount(page, ".thinking-block", 1, 15_000);
+
+    const thinkingBlocks = page.locator(".thinking-block");
+    const count = await thinkingBlocks.count();
+    expect(count).toBeGreaterThan(0);
+  });
+
+  test("thinking blocks are collapsible", async ({ page }) => {
+    await page.goto("/");
+    await switchScenario(page, "Thinking Blocks");
+    await waitForTurnCount(page, ".thinking-block", 1, 15_000);
+
+    // Collapse the picker first
+    const pickerHeader = page.locator("text=Mock").first();
+    if (await page.locator(`button:has-text("${SCENARIOS[0]}")`).isVisible()) {
+      await pickerHeader.click();
+      await page.waitForTimeout(100);
+    }
+
+    const thinkingHeader = page.locator(".thinking-header").first();
+    const thinkingContent = page.locator(".thinking-content").first();
+
+    await expect(thinkingContent).toBeVisible();
+
+    await thinkingHeader.click();
+    await expect(thinkingContent).not.toBeVisible();
+
+    await thinkingHeader.click();
+    await expect(page.locator(".thinking-content").first()).toBeVisible();
+  });
+
+  test("thinking blocks coexist with tool calls and text", async ({ page }) => {
+    await page.goto("/");
+    await switchScenario(page, "Thinking Blocks");
+    await waitForTurnCount(page, ".msg-assistant", 3, 20_000);
+    await waitForNoWorkingIndicator(page);
+
+    await expect(page.locator(".thinking-block").first()).toBeVisible();
+    await expect(page.locator(".tool-card").first()).toBeVisible();
+    await expect(page.locator(".msg-text").first()).toBeVisible();
+  });
+});
+
+// -- Streaming Slow --
+
+test.describe("Mock UI - Streaming Slow Scenario", () => {
+  test("shows working indicator during streaming", async ({ page }) => {
+    await page.goto("/");
+    await switchScenario(page, "Streaming Slow");
+    await expect(page.locator(".working-indicator")).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("renders long markdown content with tables", async ({ page }) => {
+    await page.goto("/");
+    await switchScenario(page, "Streaming Slow");
+
+    // Wait for tables to appear in the rendered markdown
+    await page.waitForFunction(
+      () => document.querySelectorAll(".msg-text table").length > 0,
+      {},
+      { timeout: 30_000 },
+    );
+
+    const tables = page.locator(".msg-text table");
+    const tableCount = await tables.count();
+    expect(tableCount).toBeGreaterThan(0);
+  });
+});
+
+// -- Error States --
+// 5 turns: truncated, tool error + model error, long output, image, fatal error
+
+test.describe("Mock UI - Error States Scenario", () => {
+  test("shows truncation warning for length-stopped responses", async ({ page }) => {
+    await page.goto("/");
+    await switchScenario(page, "Error States");
+    await waitForTurnCount(page, ".msg-assistant", 1, 10_000);
+
+    const truncatedMsg = page.locator(".msg-truncated");
+    await expect(truncatedMsg).toBeVisible({ timeout: 5_000 });
+    await expect(truncatedMsg).toContainText("cut short");
+  });
+
+  test("shows error messages for failed responses", async ({ page }) => {
+    await page.goto("/");
+    await switchScenario(page, "Error States");
+    // Turn 2 produces an error assistant message. Wait for it.
+    // Turn 1: 1 assistant, Turn 2: 2 assistants (tool + error) = 3 total
+    await waitForTurnCount(page, ".msg-error", 1, 25_000);
+
+    const errorMsgs = page.locator(".msg-error");
+    const errorCount = await errorMsgs.count();
+    expect(errorCount).toBeGreaterThan(0);
+  });
+
+  test("renders error tool card with error styling", async ({ page }) => {
+    await page.goto("/");
+    await switchScenario(page, "Error States");
+    // Turn 2 has execute_office_js error
+    await waitForTurnCount(page, ".tool-card", 1, 15_000);
+
+    const errorToolCards = page.locator(".tool-card-error");
+    await expect(errorToolCards.first()).toBeVisible({ timeout: 10_000 });
+  });
+
+  test("handles image tool results", async ({ page }) => {
+    await page.goto("/");
+    await switchScenario(page, "Error States");
+    // Turn 4 has get_range_image
+    await waitForTurnCount(page, ".msg-assistant", 6, 30_000);
+
+    // Collapse the picker first
+    const pickerHeader = page.locator("text=Mock").first();
+    if (await page.locator(`button:has-text("${SCENARIOS[0]}")`).isVisible()) {
+      await pickerHeader.click();
+      await page.waitForTimeout(100);
+    }
+
+    const imageToolCard = page.locator(".tool-card-header").filter({ hasText: "Get Range Image" });
+    if ((await imageToolCard.count()) > 0) {
+      await imageToolCard.click();
+      const toolImage = page.locator(".tool-card-image");
+      await expect(toolImage).toBeVisible({ timeout: 3_000 });
+    }
+  });
+});
+
+// -- Scenario Switching --
+
+test.describe("Mock UI - Scenario Switching", () => {
+  test("switching scenarios resets the chat", async ({ page }) => {
+    await page.goto("/");
+    await waitForTurnCount(page, ".msg-assistant", 1, 10_000);
+
+    await switchScenario(page, "Thinking Blocks");
+    await waitForTurnCount(page, ".thinking-block", 1, 15_000);
+
+    const thinkingBlocks = page.locator(".thinking-block");
+    const count = await thinkingBlocks.count();
+    expect(count).toBeGreaterThan(0);
+  });
+
+  test("reset button replays current scenario", async ({ page }) => {
+    await page.goto("/");
+    await waitForTurnCount(page, ".msg-assistant", 1, 10_000);
+
+    const resetBtn = page.locator("button:has-text('Reset')");
+    if (!(await resetBtn.isVisible())) {
+      await page.locator("text=Mock").first().click();
+      await page.waitForTimeout(100);
+    }
+    await resetBtn.click();
+
+    await waitForTurnCount(page, ".msg-assistant", 1, 15_000);
+    const msgCount = await page.locator(".msg").count();
+    expect(msgCount).toBeGreaterThan(0);
+  });
+
+  test("all five scenarios are listed in the picker", async ({ page }) => {
+    await page.goto("/");
+
+    const firstScenarioBtn = page.locator(`button:has-text("${SCENARIOS[0]}")`);
+    if (!(await firstScenarioBtn.isVisible())) {
+      await page.locator("text=Mock").first().click();
+    }
+
+    for (const name of SCENARIOS) {
+      await expect(page.locator(`button:has-text("${name}")`)).toBeVisible();
+    }
+  });
+});
+
+// -- Chat Input --
+
+test.describe("Mock UI - Chat Input", () => {
+  test("can type in the input area", async ({ page }) => {
+    await page.goto("/");
+
+    const input = page.locator("textarea, input[type='text']").first();
+    await input.fill("Hello mock!");
+
+    const value = await input.inputValue();
+    expect(value).toBe("Hello mock!");
+  });
+
+  test("new chat button clears all messages", async ({ page }) => {
+    await page.goto("/");
+    await waitForTurnCount(page, ".msg", 1, 10_000);
+
+    // Collapse the picker first
+    const pickerHeader = page.locator("text=Mock").first();
+    if (await page.locator(`button:has-text("${SCENARIOS[0]}")`).isVisible()) {
+      await pickerHeader.click();
+      await page.waitForTimeout(100);
+    }
+
+    const newChatBtn = page.locator("button[title='New Chat']");
+    await newChatBtn.click();
+
+    await expect(page.locator(".thread-empty")).toBeVisible({ timeout: 3_000 });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "certs:install": "office-addin-dev-certs install",
     "certs:verify": "office-addin-dev-certs verify",
     "dev": "vite",
+    "dev:mock": "vite --config vite.config.mock.ts",
+    "dev:stop": "lsof -ti :5173 | xargs kill -9 2>/dev/null || echo 'No dev server running on port 5173'",
     "build": "tsc -b && vite build",
     "manifest:validate": "office-addin-manifest validate manifest.xml",
     "lint": "biome check .",
@@ -18,15 +20,18 @@
     "typecheck": "tsc --noEmit -p tsconfig.app.json",
     "e2e": "playwright test",
     "e2e:headed": "playwright test --headed",
+    "e2e:mock": "playwright test --config playwright.config.mock.ts",
+    "e2e:mock:headed": "playwright test --config playwright.config.mock.ts --headed",
     "e2e:step": "node e2e/step.cjs"
   },
   "dependencies": {
-    "@assistant-ui/react": "^0.12.23",
     "@mariozechner/pi-agent-core": "^0.65.2",
     "@mariozechner/pi-ai": "^0.65.2",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-markdown": "^10.1.0",
     "react-router-dom": "^7.9.6",
+    "remark-gfm": "^4.0.1",
     "zustand": "^5.0.8"
   },
   "devDependencies": {

--- a/playwright.config.mock.ts
+++ b/playwright.config.mock.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  testMatch: "mock-ui.spec.ts",
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
+  fullyParallel: false,
+  retries: 0,
+  reporter: "list",
+  use: {
+    browserName: "chromium",
+    headless: true,
+    viewport: { width: 400, height: 700 },
+    baseURL: "http://localhost:5174",
+  },
+  webServer: {
+    command: "bun run dev:mock",
+    url: "http://localhost:5174",
+    reuseExistingServer: true,
+    timeout: 15_000,
+  },
+});

--- a/src/mock/MockWorkbenchPage.tsx
+++ b/src/mock/MockWorkbenchPage.tsx
@@ -1,0 +1,288 @@
+import type { AgentEvent, AgentMessage } from "@mariozechner/pi-agent-core";
+import { startTransition, useCallback, useEffect, useRef, useState } from "react";
+import { ChatThread } from "../components/ChatThread";
+import { ErrorLogPanel } from "../components/ErrorLogPanel";
+import { bridgeAgentEvent } from "../lib/agent/eventBridge";
+import { convertMessages } from "../lib/chat/types";
+import type { DebugTurnRecord } from "../lib/debug/runtimeEvents";
+import type { MockScenario } from "./mockAgentDriver";
+import { MockAgentDriver } from "./mockAgentDriver";
+import { ScenarioPicker } from "./ScenarioPicker";
+import { ALL_SCENARIOS } from "./scenarioLoader";
+
+const MOCK_MODEL_ID = "mock-model";
+
+export function MockWorkbenchPage() {
+  const [showDebug, setShowDebug] = useState(false);
+  const [debugTurns, setDebugTurns] = useState<DebugTurnRecord[]>([]);
+  const [messages, setMessages] = useState<AgentMessage[]>([]);
+  const [isRunning, setIsRunning] = useState(false);
+  const [scenario, setScenario] = useState<MockScenario>(ALL_SCENARIOS[0] as MockScenario);
+  const [scenarioKey, setScenarioKey] = useState(0);
+
+  const driverRef = useRef<MockAgentDriver>(new MockAgentDriver());
+  const iterationRef = useRef(0);
+  const turnStartRef = useRef(0);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scenarioKey forces re-run when resetting same scenario
+  useEffect(() => {
+    const driver = driverRef.current;
+
+    const unsubscribe = driver.subscribe((event: AgentEvent) => {
+      setMessages([...driver.state.messages]);
+      setIsRunning(driver.state.isStreaming);
+
+      const runtimeEvent = bridgeAgentEvent(
+        event,
+        iterationRef.current,
+        turnStartRef.current,
+        MOCK_MODEL_ID,
+        driver.state.messages.length,
+      );
+
+      if (event.type === "turn_start") {
+        iterationRef.current += 1;
+      }
+
+      if (runtimeEvent) {
+        startTransition(() => {
+          setDebugTurns((current) => {
+            const turnId = current[0]?.id;
+            if (!turnId) return current;
+            return current.map((turn) =>
+              turn.id === turnId ? { ...turn, events: [...turn.events, runtimeEvent] } : turn,
+            );
+          });
+        });
+      }
+    });
+
+    driver.loadScenario(scenario);
+
+    // Auto-play all turns in sequence
+    if (scenario.autoPlay && scenario.turns.length > 0) {
+      let cancelled = false;
+      const autoplay = async () => {
+        for (const turn of scenario.turns) {
+          if (cancelled) break;
+
+          turnStartRef.current = Date.now();
+          iterationRef.current = 0;
+
+          const turnId = crypto.randomUUID();
+          setDebugTurns((current) => [
+            {
+              id: turnId,
+              prompt: turn.userMessage,
+              startedAt: Date.now(),
+              status: "running",
+              events: [],
+            },
+            ...current,
+          ]);
+
+          try {
+            await driver.prompt(turn.userMessage);
+            if (cancelled) break;
+            setDebugTurns((current) =>
+              current.map((t) =>
+                t.id === turnId ? { ...t, finishedAt: Date.now(), status: "completed" } : t,
+              ),
+            );
+          } catch {
+            break;
+          }
+
+          // Pause between turns
+          if (!cancelled) {
+            await new Promise((r) => setTimeout(r, scenario.streamDelay ?? 500));
+          }
+        }
+      };
+
+      void autoplay();
+
+      return () => {
+        cancelled = true;
+        unsubscribe();
+        driver.abort();
+      };
+    }
+
+    return () => {
+      unsubscribe();
+      driver.abort();
+    };
+  }, [scenario, scenarioKey]);
+
+  const handleSend = useCallback(async (text: string) => {
+    const driver = driverRef.current;
+
+    const turnId = crypto.randomUUID();
+    iterationRef.current = 0;
+    turnStartRef.current = Date.now();
+
+    setDebugTurns((current) => [
+      {
+        id: turnId,
+        prompt: text,
+        startedAt: Date.now(),
+        status: "running",
+        events: [],
+      },
+      ...current,
+    ]);
+
+    try {
+      await driver.prompt(text);
+      setIsRunning(false);
+      setDebugTurns((current) =>
+        current.map((turn) =>
+          turn.id === turnId ? { ...turn, finishedAt: Date.now(), status: "completed" } : turn,
+        ),
+      );
+    } catch (error) {
+      setIsRunning(false);
+      const content = error instanceof Error ? error.message : String(error);
+      setDebugTurns((current) =>
+        current.map((turn) =>
+          turn.id === turnId
+            ? { ...turn, finishedAt: Date.now(), status: "failed", summary: content }
+            : turn,
+        ),
+      );
+    }
+  }, []);
+
+  const handleStop = useCallback(() => {
+    driverRef.current.abort();
+  }, []);
+
+  const handleNewChat = useCallback(() => {
+    driverRef.current.reset();
+    setMessages([]);
+    setDebugTurns([]);
+  }, []);
+
+  const handleScenarioSwitch = useCallback((newScenario: MockScenario) => {
+    const driver = driverRef.current;
+    driver.reset();
+    setMessages([]);
+    setDebugTurns([]);
+    setIsRunning(false);
+    setScenario(newScenario);
+    setScenarioKey((k) => k + 1);
+  }, []);
+
+  const chatMessages = convertMessages(messages);
+
+  return (
+    <>
+      <main className="app-shell">
+        <header className="app-header">
+          <div className="app-header-left">
+            <h1 className="app-title">OpenExcel</h1>
+            <span className="pill">mock</span>
+          </div>
+          <div className="app-header-right">
+            <button
+              className="icon-button"
+              type="button"
+              onClick={() => setShowDebug((prev) => !prev)}
+              title={showDebug ? "Hide Debug" : "Debug"}
+            >
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 16 16"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <title>Debug</title>
+                <path d="M5.5 2.5L3 5M10.5 2.5L13 5" />
+                <path d="M2 8h2.5M11.5 8H14" />
+                <path d="M3 11l2.5-1M13 11l-2.5-1" />
+                <rect x="5" y="4" width="6" height="8" rx="3" />
+                <path d="M8 4v8" />
+              </svg>
+            </button>
+            <button className="icon-button" type="button" onClick={handleNewChat} title="New Chat">
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 16 16"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <title>New Chat</title>
+                <path d="M8 3v10M3 8h10" />
+              </svg>
+            </button>
+          </div>
+        </header>
+
+        <div className="app-content">
+          <div className="chat-area">
+            <ChatThread
+              messages={chatMessages}
+              isRunning={isRunning}
+              onSend={handleSend}
+              onStop={handleStop}
+              disabled={false}
+              turnStartedAt={turnStartRef.current}
+            />
+          </div>
+
+          {showDebug && (
+            <aside className="debug-overlay">
+              <div className="debug-overlay-header">
+                <h2>Debug</h2>
+                <button
+                  className="debug-close-btn"
+                  type="button"
+                  onClick={() => setShowDebug(false)}
+                >
+                  Close
+                </button>
+              </div>
+
+              <ErrorLogPanel />
+
+              <section className="debug-timeline">
+                <div className="debug-section-header">
+                  <h3>Timeline</h3>
+                </div>
+                <div className="debug-turns">
+                  {debugTurns.map((turn) => (
+                    <article className="debug-turn" key={turn.id}>
+                      <div className="turn-summary">
+                        <span className={`turn-status turn-status-${turn.status}`}>
+                          {turn.status}
+                        </span>
+                        <span className="turn-events">{turn.events.length} events</span>
+                      </div>
+                      <pre className="turn-prompt">{turn.prompt}</pre>
+                      {turn.summary && <pre className="turn-result">{turn.summary}</pre>}
+                    </article>
+                  ))}
+                </div>
+              </section>
+            </aside>
+          )}
+        </div>
+      </main>
+
+      <ScenarioPicker
+        driver={driverRef.current}
+        currentScenario={scenario}
+        onSwitch={handleScenarioSwitch}
+      />
+    </>
+  );
+}

--- a/src/mock/ScenarioPicker.tsx
+++ b/src/mock/ScenarioPicker.tsx
@@ -1,0 +1,136 @@
+import { useState } from "react";
+import type { MockAgentDriver, MockScenario } from "./mockAgentDriver";
+import { ALL_SCENARIOS } from "./scenarioLoader";
+
+type ScenarioPickerProps = {
+  readonly driver: MockAgentDriver;
+  readonly currentScenario: MockScenario;
+  readonly onSwitch: (scenario: MockScenario) => void;
+};
+
+export function ScenarioPicker({ driver, currentScenario, onSwitch }: ScenarioPickerProps) {
+  const [collapsed, setCollapsed] = useState(false);
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        bottom: 8,
+        left: 8,
+        zIndex: 9999,
+        background: "#1a1a2e",
+        color: "#e0e0e0",
+        borderRadius: 8,
+        boxShadow: "0 4px 12px rgba(0,0,0,0.3)",
+        fontSize: 12,
+        fontFamily: "system-ui, sans-serif",
+        minWidth: collapsed ? "auto" : 220,
+        overflow: "hidden",
+      }}
+    >
+      <button
+        type="button"
+        onClick={() => setCollapsed((prev) => !prev)}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          width: "100%",
+          padding: "8px 12px",
+          border: "none",
+          background: "#16213e",
+          color: "#e0e0e0",
+          cursor: "pointer",
+          fontSize: 12,
+          fontWeight: 600,
+        }}
+      >
+        <span style={{ fontSize: 14 }}>Mock</span>
+        <span style={{ opacity: 0.6, flex: 1, textAlign: "left" }}>
+          {collapsed ? currentScenario.name : ""}
+        </span>
+        <span style={{ fontSize: 10 }}>{collapsed ? "+" : "-"}</span>
+      </button>
+
+      {!collapsed && (
+        <div style={{ padding: "4px 8px 8px" }}>
+          <div
+            style={{
+              marginBottom: 6,
+              opacity: 0.5,
+              fontSize: 10,
+              textTransform: "uppercase",
+              letterSpacing: 1,
+            }}
+          >
+            Scenarios
+          </div>
+          {ALL_SCENARIOS.map((scenario) => (
+            <button
+              type="button"
+              key={scenario.name}
+              onClick={() => onSwitch(scenario)}
+              style={{
+                display: "block",
+                width: "100%",
+                textAlign: "left",
+                padding: "6px 8px",
+                margin: "2px 0",
+                border: "none",
+                borderRadius: 4,
+                cursor: "pointer",
+                fontSize: 11,
+                background: scenario.name === currentScenario.name ? "#0f3460" : "transparent",
+                color: scenario.name === currentScenario.name ? "#7ec8e3" : "#c0c0c0",
+                fontWeight: scenario.name === currentScenario.name ? 600 : 400,
+              }}
+            >
+              {scenario.name}
+            </button>
+          ))}
+
+          <div style={{ marginTop: 8, display: "flex", gap: 4 }}>
+            <button
+              type="button"
+              onClick={() => onSwitch(currentScenario)}
+              style={{
+                flex: 1,
+                padding: "5px 8px",
+                border: "1px solid #333",
+                borderRadius: 4,
+                background: "#1a1a2e",
+                color: "#e0e0e0",
+                cursor: "pointer",
+                fontSize: 11,
+              }}
+            >
+              Reset
+            </button>
+            {driver.hasNextTurn && !currentScenario.autoPlay && (
+              <button
+                type="button"
+                onClick={() => driver.promptNextTurn()}
+                style={{
+                  flex: 1,
+                  padding: "5px 8px",
+                  border: "1px solid #333",
+                  borderRadius: 4,
+                  background: "#0f3460",
+                  color: "#7ec8e3",
+                  cursor: "pointer",
+                  fontSize: 11,
+                }}
+              >
+                Next Turn
+              </button>
+            )}
+          </div>
+
+          <div style={{ marginTop: 6, fontSize: 10, opacity: 0.4 }}>
+            Turn {driver.currentTurnIndex}/{driver.totalTurns}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/mock/fixtures/basic-chat.json
+++ b/src/mock/fixtures/basic-chat.json
@@ -1,0 +1,68 @@
+{
+  "name": "Basic Chat",
+  "description": "Simple text-only Q&A conversation with markdown rendering",
+  "autoPlay": true,
+  "streamDelay": 600,
+  "turns": [
+    {
+      "userMessage": "What can you help me with?",
+      "events": [
+        { "type": "turn_start", "delay": 200 },
+        {
+          "type": "turn_end",
+          "delay": 300,
+          "message": {
+            "content": [
+              {
+                "type": "text",
+                "text": "I can help you with a variety of Excel tasks:\n\n- **Reading data** from your worksheets\n- **Writing values** and formulas to cells\n- **Formatting** headers, borders, and cell styles\n- **Creating charts** and visual summaries\n- **Analyzing data** with formulas and pivot-like summaries\n\nJust tell me what you'd like to do with your workbook!"
+              }
+            ],
+            "stopReason": "stop",
+            "usage": { "input": 850, "output": 120 }
+          }
+        }
+      ]
+    },
+    {
+      "userMessage": "Can you show me a code example of a SUM formula?",
+      "events": [
+        { "type": "turn_start", "delay": 150 },
+        {
+          "type": "turn_end",
+          "delay": 400,
+          "message": {
+            "content": [
+              {
+                "type": "text",
+                "text": "Here's how SUM formulas work in Excel:\n\n```\n=SUM(B2:B10)\n```\n\nYou can also sum across multiple ranges:\n\n```\n=SUM(B2:B10, D2:D10)\n```\n\nOr use conditional summing with `SUMIF`:\n\n| Formula | Description |\n|---------|-------------|\n| `=SUM(A1:A10)` | Sum a simple range |\n| `=SUMIF(A:A, \"Widget\", B:B)` | Sum where column A matches |\n| `=SUMPRODUCT(A1:A5, B1:B5)` | Multiply and sum pairs |\n\nWould you like me to add a SUM formula to your workbook?"
+              }
+            ],
+            "stopReason": "stop",
+            "usage": { "input": 1200, "output": 210 }
+          }
+        }
+      ]
+    },
+    {
+      "userMessage": "Yes, add a total row to the Sales sheet",
+      "events": [
+        { "type": "turn_start", "delay": 100 },
+        {
+          "type": "turn_end",
+          "delay": 500,
+          "message": {
+            "content": [
+              {
+                "type": "text",
+                "text": "I've added a **Total** row at row 5 of the Sales sheet with SUM formulas for each quarter column. The totals are:\n\n- Q1: **27,000**\n- Q2: **29,500**\n- Q3: **29,100**\n- Q4: **36,200**\n- Grand Total: **121,800**\n\nAll values are calculated with `=SUM()` formulas so they'll update automatically."
+              }
+            ],
+            "stopReason": "stop",
+            "usage": { "input": 1500, "output": 95 }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/mock/fixtures/error-states.json
+++ b/src/mock/fixtures/error-states.json
@@ -1,0 +1,231 @@
+{
+  "name": "Error States",
+  "description": "Edge cases: truncation, errors, empty content, long output, image results",
+  "autoPlay": true,
+  "streamDelay": 1000,
+  "turns": [
+    {
+      "userMessage": "Write a very detailed analysis of the entire workbook",
+      "events": [
+        { "type": "turn_start", "delay": 200 },
+        {
+          "type": "turn_end",
+          "delay": 500,
+          "message": {
+            "content": [
+              {
+                "type": "text",
+                "text": "# Comprehensive Workbook Analysis\n\n## Sales Sheet\n\nThe Sales sheet contains quarterly revenue data for three products across four quarters. Widget A leads with $54,800 in total revenue, followed by Widget B at $39,700 and Widget C at $27,300.\n\n## Growth Trends\n\nAll products show positive growth trajectories with Widget C showing the strongest momentum at 50% year-over-year growth. This suggests a market shift toward..."
+              }
+            ],
+            "stopReason": "length",
+            "usage": { "input": 1500, "output": 4096 }
+          }
+        }
+      ]
+    },
+    {
+      "userMessage": "Try running some complex Office.js code",
+      "events": [
+        { "type": "turn_start", "delay": 200 },
+        {
+          "type": "turn_end",
+          "delay": 100,
+          "message": {
+            "content": [
+              {
+                "type": "toolCall",
+                "id": "tc_e1",
+                "name": "execute_office_js",
+                "arguments": {
+                  "code": "const sheet = context.workbook.worksheets.getItem('NonExistent');\nsheet.load('name');\nawait context.sync();"
+                }
+              }
+            ],
+            "stopReason": "toolUse",
+            "usage": { "input": 1800, "output": 55 }
+          }
+        },
+        {
+          "type": "tool_execution_start",
+          "toolCallId": "tc_e1",
+          "toolName": "execute_office_js",
+          "args": {},
+          "delay": 100
+        },
+        {
+          "type": "tool_execution_end",
+          "toolCallId": "tc_e1",
+          "toolName": "execute_office_js",
+          "result": {
+            "content": [
+              {
+                "type": "text",
+                "text": "Error: ItemNotFound - The requested resource doesn't exist.\n\nStack:\nError: ItemNotFound\n    at Excel.Worksheet._processResult\n    at Excel.RequestContext.processRequestExecutorResponseMessage"
+              }
+            ]
+          },
+          "isError": true,
+          "delay": 400
+        },
+        { "type": "turn_start", "delay": 200 },
+        {
+          "type": "turn_end",
+          "delay": 300,
+          "message": {
+            "content": [
+              {
+                "type": "text",
+                "text": ""
+              }
+            ],
+            "stopReason": "error",
+            "errorMessage": "The model encountered an internal error while processing the tool result. Please try again.",
+            "usage": { "input": 2200, "output": 0 }
+          }
+        }
+      ]
+    },
+    {
+      "userMessage": "Read all the data from the Inventory sheet",
+      "events": [
+        { "type": "turn_start", "delay": 200 },
+        {
+          "type": "turn_end",
+          "delay": 100,
+          "message": {
+            "content": [
+              {
+                "type": "toolCall",
+                "id": "tc_e2",
+                "name": "get_cell_ranges",
+                "arguments": { "sheetName": "Inventory", "ranges": ["A1:D100"] }
+              }
+            ],
+            "stopReason": "toolUse",
+            "usage": { "input": 1200, "output": 50 }
+          }
+        },
+        {
+          "type": "tool_execution_start",
+          "toolCallId": "tc_e2",
+          "toolName": "get_cell_ranges",
+          "args": { "sheetName": "Inventory", "ranges": ["A1:D100"] },
+          "delay": 100
+        },
+        {
+          "type": "tool_execution_end",
+          "toolCallId": "tc_e2",
+          "toolName": "get_cell_ranges",
+          "result": {
+            "content": [
+              {
+                "type": "text",
+                "text": "{\n  \"success\": true,\n  \"worksheet\": {\n    \"name\": \"Inventory\",\n    \"dimension\": { \"rows\": 100, \"columns\": 4 },\n    \"cells\": {\n      \"A1\": { \"value\": \"Item\" }, \"B1\": { \"value\": \"SKU\" }, \"C1\": { \"value\": \"Quantity\" }, \"D1\": { \"value\": \"Location\" },\n      \"A2\": { \"value\": \"Widget A\" }, \"B2\": { \"value\": \"WA-001\" }, \"C2\": { \"value\": 342 }, \"D2\": { \"value\": \"Warehouse 1\" },\n      \"A3\": { \"value\": \"Widget B\" }, \"B3\": { \"value\": \"WB-002\" }, \"C3\": { \"value\": 128 }, \"D3\": { \"value\": \"Warehouse 2\" },\n      \"A4\": { \"value\": \"Widget C\" }, \"B4\": { \"value\": \"WC-003\" }, \"C4\": { \"value\": 56 }, \"D4\": { \"value\": \"Warehouse 1\" },\n      \"A5\": { \"value\": \"Gadget X\" }, \"B5\": { \"value\": \"GX-004\" }, \"C5\": { \"value\": 891 }, \"D5\": { \"value\": \"Warehouse 3\" },\n      \"A6\": { \"value\": \"Gadget Y\" }, \"B6\": { \"value\": \"GY-005\" }, \"C6\": { \"value\": 234 }, \"D6\": { \"value\": \"Warehouse 1\" },\n      \"A7\": { \"value\": \"Gadget Z\" }, \"B7\": { \"value\": \"GZ-006\" }, \"C7\": { \"value\": 67 }, \"D7\": { \"value\": \"Warehouse 2\" },\n      \"A8\": { \"value\": \"Doohickey Alpha\" }, \"B8\": { \"value\": \"DA-007\" }, \"C8\": { \"value\": 1205 }, \"D8\": { \"value\": \"Warehouse 1\" },\n      \"A9\": { \"value\": \"Doohickey Beta\" }, \"B9\": { \"value\": \"DB-008\" }, \"C9\": { \"value\": 543 }, \"D9\": { \"value\": \"Warehouse 3\" },\n      \"A10\": { \"value\": \"Thingamajig Pro\" }, \"B10\": { \"value\": \"TP-009\" }, \"C10\": { \"value\": 12 }, \"D10\": { \"value\": \"Warehouse 2\" },\n      \"A11\": { \"value\": \"Thingamajig Lite\" }, \"B11\": { \"value\": \"TL-010\" }, \"C11\": { \"value\": 3 }, \"D11\": { \"value\": \"Warehouse 1\" },\n      \"A12\": { \"value\": \"Contraption M1\" }, \"B12\": { \"value\": \"CM-011\" }, \"C12\": { \"value\": 445 }, \"D12\": { \"value\": \"Warehouse 3\" },\n      \"A13\": { \"value\": \"Contraption M2\" }, \"B13\": { \"value\": \"CM-012\" }, \"C13\": { \"value\": 290 }, \"D13\": { \"value\": \"Warehouse 2\" },\n      \"A14\": { \"value\": \"Apparatus 1\" }, \"B14\": { \"value\": \"AP-013\" }, \"C14\": { \"value\": 178 }, \"D14\": { \"value\": \"Warehouse 1\" },\n      \"A15\": { \"value\": \"Apparatus 2\" }, \"B15\": { \"value\": \"AP-014\" }, \"C15\": { \"value\": 99 }, \"D15\": { \"value\": \"Warehouse 3\" },\n      \"A16\": { \"value\": \"Apparatus 3\" }, \"B16\": { \"value\": \"AP-015\" }, \"C16\": { \"value\": 56 }, \"D16\": { \"value\": \"Warehouse 2\" },\n      \"A17\": { \"value\": \"Mechanism Standard\" }, \"B17\": { \"value\": \"MS-016\" }, \"C17\": { \"value\": 812 }, \"D17\": { \"value\": \"Warehouse 1\" },\n      \"A18\": { \"value\": \"Mechanism Deluxe\" }, \"B18\": { \"value\": \"MD-017\" }, \"C18\": { \"value\": 334 }, \"D18\": { \"value\": \"Warehouse 3\" },\n      \"A19\": { \"value\": \"Part 9001\" }, \"B19\": { \"value\": \"PT-018\" }, \"C19\": { \"value\": 10000 }, \"D19\": { \"value\": \"Warehouse 1\" },\n      \"A20\": { \"value\": \"Part 9002\" }, \"B20\": { \"value\": \"PT-019\" }, \"C20\": { \"value\": 8500 }, \"D20\": { \"value\": \"Warehouse 2\" }\n    }\n  }\n}"
+              }
+            ]
+          },
+          "isError": false,
+          "delay": 800
+        },
+        { "type": "turn_start", "delay": 200 },
+        {
+          "type": "turn_end",
+          "delay": 400,
+          "message": {
+            "content": [
+              {
+                "type": "text",
+                "text": "The Inventory sheet contains **19 items** across 3 warehouses. Here's the summary:\n\n| Warehouse | Items | Total Qty |\n|-----------|-------|-----------|\n| Warehouse 1 | 8 | 13,651 |\n| Warehouse 2 | 6 | 9,174 |\n| Warehouse 3 | 5 | 2,513 |\n\nLow stock alerts (< 100 units):\n- Thingamajig Lite: **3 units** (critical)\n- Thingamajig Pro: **12 units** (low)\n- Widget C: **56 units** (low)\n- Apparatus 3: **56 units** (low)\n- Gadget Z: **67 units** (low)\n- Apparatus 2: **99 units** (low)"
+              }
+            ],
+            "stopReason": "stop",
+            "usage": { "input": 3500, "output": 200 }
+          }
+        }
+      ]
+    },
+    {
+      "userMessage": "Take a screenshot of the Sales data range",
+      "events": [
+        { "type": "turn_start", "delay": 200 },
+        {
+          "type": "turn_end",
+          "delay": 100,
+          "message": {
+            "content": [
+              {
+                "type": "toolCall",
+                "id": "tc_e3",
+                "name": "get_range_image",
+                "arguments": { "sheetName": "Sales", "range": "A1:F4" }
+              }
+            ],
+            "stopReason": "toolUse",
+            "usage": { "input": 1400, "output": 45 }
+          }
+        },
+        {
+          "type": "tool_execution_start",
+          "toolCallId": "tc_e3",
+          "toolName": "get_range_image",
+          "args": { "sheetName": "Sales", "range": "A1:F4" },
+          "delay": 100
+        },
+        {
+          "type": "tool_execution_end",
+          "toolCallId": "tc_e3",
+          "toolName": "get_range_image",
+          "result": {
+            "content": [
+              { "type": "text", "text": "Image captured for A1:F4 on sheet \"Sales\"." },
+              {
+                "type": "image",
+                "data": "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFklEQVQYV2P8z8BQz0BFwMgwasCoAgBMNAYRjjW2YQAAAABJRU5ErkJggg==",
+                "mimeType": "image/png"
+              }
+            ]
+          },
+          "isError": false,
+          "delay": 600
+        },
+        { "type": "turn_start", "delay": 200 },
+        {
+          "type": "turn_end",
+          "delay": 300,
+          "message": {
+            "content": [
+              {
+                "type": "text",
+                "text": "Here's the screenshot of the Sales data range (A1:F4). The image shows the product names, quarterly sales figures, and totals.\n\nNote: In the mock environment, this is a placeholder image. In the actual Excel environment, you would see the formatted spreadsheet data."
+              }
+            ],
+            "stopReason": "stop",
+            "usage": { "input": 2000, "output": 55 }
+          }
+        }
+      ]
+    },
+    {
+      "userMessage": "Do something that will fail completely",
+      "events": [
+        { "type": "turn_start", "delay": 200 },
+        {
+          "type": "turn_end",
+          "delay": 300,
+          "message": {
+            "content": [
+              {
+                "type": "text",
+                "text": ""
+              }
+            ],
+            "stopReason": "error",
+            "errorMessage": "Connection reset: The upstream provider returned HTTP 502. This is usually a transient error. Please retry your request.",
+            "usage": { "input": 500, "output": 0 }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/mock/fixtures/streaming-slow.json
+++ b/src/mock/fixtures/streaming-slow.json
@@ -1,0 +1,158 @@
+{
+  "name": "Streaming Slow",
+  "description": "Slow streaming simulation for testing scroll and animation behaviors",
+  "autoPlay": true,
+  "streamDelay": 2000,
+  "turns": [
+    {
+      "userMessage": "Give me a detailed quarterly sales report",
+      "events": [
+        { "type": "turn_start", "delay": 500 },
+        {
+          "type": "turn_end",
+          "delay": 100,
+          "message": {
+            "content": [
+              {
+                "type": "toolCall",
+                "id": "tc_s1",
+                "name": "get_cell_ranges",
+                "arguments": { "sheetName": "Sales", "ranges": ["A1:F4"] }
+              }
+            ],
+            "stopReason": "toolUse",
+            "usage": { "input": 1000, "output": 50 }
+          }
+        },
+        {
+          "type": "tool_execution_start",
+          "toolCallId": "tc_s1",
+          "toolName": "get_cell_ranges",
+          "args": { "sheetName": "Sales", "ranges": ["A1:F4"] },
+          "delay": 200
+        },
+        {
+          "type": "tool_execution_end",
+          "toolCallId": "tc_s1",
+          "toolName": "get_cell_ranges",
+          "result": {
+            "content": [
+              {
+                "type": "text",
+                "text": "{ \"success\": true, \"worksheet\": { \"name\": \"Sales\", \"cells\": { \"A1\": {\"value\":\"Product\"}, \"B1\": {\"value\":\"Q1\"}, \"C1\": {\"value\":\"Q2\"}, \"D1\": {\"value\":\"Q3\"}, \"E1\": {\"value\":\"Q4\"}, \"F1\": {\"value\":\"Total\"}, \"A2\": {\"value\":\"Widget A\"}, \"B2\": {\"value\":12500}, \"C2\": {\"value\":14200}, \"D2\": {\"value\":11800}, \"E2\": {\"value\":16300}, \"F2\": {\"value\":54800}, \"A3\": {\"value\":\"Widget B\"}, \"B3\": {\"value\":8900}, \"C3\": {\"value\":9200}, \"D3\": {\"value\":10100}, \"E3\": {\"value\":11500}, \"F3\": {\"value\":39700}, \"A4\": {\"value\":\"Widget C\"}, \"B4\": {\"value\":5600}, \"C4\": {\"value\":6100}, \"D4\": {\"value\":7200}, \"E4\": {\"value\":8400}, \"F4\": {\"value\":27300} } } }"
+              }
+            ]
+          },
+          "isError": false,
+          "delay": 1500
+        },
+        { "type": "turn_start", "delay": 500 },
+        {
+          "type": "turn_end",
+          "delay": 1000,
+          "message": {
+            "content": [
+              {
+                "type": "text",
+                "text": "# Quarterly Sales Report\n\n## Overview\n\nTotal revenue across all products for the fiscal year: **$121,800**\n\nThe product portfolio shows healthy growth across all three product lines, with Widget A maintaining its position as the flagship product.\n\n## Performance by Product\n\n### Widget A (Revenue Leader)\n\n| Quarter | Revenue | QoQ Change |\n|---------|---------|------------|\n| Q1 | $12,500 | - |\n| Q2 | $14,200 | +13.6% |\n| Q3 | $11,800 | -16.9% |\n| Q4 | $16,300 | +38.1% |\n| **Total** | **$54,800** | |\n\nWidget A accounts for **45.0%** of total revenue. Strong Q4 rebound after Q3 dip.\n\n### Widget B (Steady Performer)\n\n| Quarter | Revenue | QoQ Change |\n|---------|---------|------------|\n| Q1 | $8,900 | - |\n| Q2 | $9,200 | +3.4% |\n| Q3 | $10,100 | +9.8% |\n| Q4 | $11,500 | +13.9% |\n| **Total** | **$39,700** | |\n\nWidget B shows the most **consistent growth** — no negative quarters. Accounts for **32.6%** of revenue.\n\n### Widget C (Growth Star)\n\n| Quarter | Revenue | QoQ Change |\n|---------|---------|------------|\n| Q1 | $5,600 | - |\n| Q2 | $6,100 | +8.9% |\n| Q3 | $7,200 | +18.0% |\n| Q4 | $8,400 | +16.7% |\n| **Total** | **$27,300** | |\n\nWidget C is the **fastest-growing product** with 50% year-over-year growth (Q1 vs Q4). Accounts for **22.4%** of revenue.\n\n## Quarterly Totals\n\n| Quarter | Total Revenue | QoQ Change |\n|---------|--------------|------------|\n| Q1 | $27,000 | - |\n| Q2 | $29,500 | +9.3% |\n| Q3 | $29,100 | -1.4% |\n| Q4 | $36,200 | +24.4% |\n\n## Key Takeaways\n\n1. **Q4 was the strongest quarter** at $36,200 (+24.4% QoQ)\n2. **Q3 showed a slight dip** driven by Widget A's seasonal decline\n3. **Widget C's trajectory** suggests it could surpass Widget B by mid-next-year\n4. **Portfolio diversification** is improving — Widget A's share dropped from 46.3% (Q1) to 45.0% (full year) as other products grow faster"
+              }
+            ],
+            "stopReason": "stop",
+            "usage": { "input": 2500, "output": 850 }
+          }
+        }
+      ]
+    },
+    {
+      "userMessage": "Now format that report and write it to the Summary sheet",
+      "events": [
+        { "type": "turn_start", "delay": 800 },
+        {
+          "type": "turn_end",
+          "delay": 100,
+          "message": {
+            "content": [
+              {
+                "type": "toolCall",
+                "id": "tc_s2",
+                "name": "set_cell_range",
+                "arguments": {
+                  "sheetName": "Summary",
+                  "cells": {
+                    "A1": { "value": "Quarterly Sales Report" },
+                    "A3": { "value": "Product" },
+                    "B3": { "value": "Q1" },
+                    "C3": { "value": "Q2" },
+                    "D3": { "value": "Q3" },
+                    "E3": { "value": "Q4" },
+                    "F3": { "value": "Total" },
+                    "G3": { "value": "Growth" }
+                  }
+                }
+              },
+              {
+                "type": "toolCall",
+                "id": "tc_s3",
+                "name": "execute_office_js",
+                "arguments": {
+                  "code": "const sheet = context.workbook.worksheets.getItem('Summary');\nconst title = sheet.getRange('A1:G1');\ntitle.merge();\ntitle.format.font.size = 14;\ntitle.format.font.bold = true;\nconst header = sheet.getRange('A3:G3');\nheader.format.fill.color = '#4472C4';\nheader.format.font.color = '#FFFFFF';\nheader.format.font.bold = true;\nawait context.sync();"
+                }
+              }
+            ],
+            "stopReason": "toolUse",
+            "usage": { "input": 3500, "output": 180 }
+          }
+        },
+        {
+          "type": "tool_execution_start",
+          "toolCallId": "tc_s2",
+          "toolName": "set_cell_range",
+          "args": {},
+          "delay": 200
+        },
+        {
+          "type": "tool_execution_end",
+          "toolCallId": "tc_s2",
+          "toolName": "set_cell_range",
+          "result": {
+            "content": [{ "type": "text", "text": "{ \"success\": true }" }]
+          },
+          "isError": false,
+          "delay": 800
+        },
+        {
+          "type": "tool_execution_start",
+          "toolCallId": "tc_s3",
+          "toolName": "execute_office_js",
+          "args": {},
+          "delay": 100
+        },
+        {
+          "type": "tool_execution_end",
+          "toolCallId": "tc_s3",
+          "toolName": "execute_office_js",
+          "result": {
+            "content": [{ "type": "text", "text": "{ \"success\": true }" }]
+          },
+          "isError": false,
+          "delay": 1200
+        },
+        { "type": "turn_start", "delay": 500 },
+        {
+          "type": "turn_end",
+          "delay": 800,
+          "message": {
+            "content": [
+              {
+                "type": "text",
+                "text": "I've written the report to the **Summary** sheet with formatting:\n\n- Title row merged and styled at 14pt bold\n- Header row with blue background and white text\n- Data rows with values and growth percentages\n\nThe report is ready for review."
+              }
+            ],
+            "stopReason": "stop",
+            "usage": { "input": 4000, "output": 75 }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/mock/fixtures/thinking.json
+++ b/src/mock/fixtures/thinking.json
@@ -1,0 +1,180 @@
+{
+  "name": "Thinking Blocks",
+  "description": "Demonstrates thinking/reasoning blocks with tool calls",
+  "autoPlay": true,
+  "streamDelay": 800,
+  "turns": [
+    {
+      "userMessage": "Analyze the sales data and tell me which product is performing best",
+      "events": [
+        { "type": "turn_start", "delay": 200 },
+        {
+          "type": "turn_end",
+          "delay": 100,
+          "message": {
+            "content": [
+              {
+                "type": "thinking",
+                "thinking": "The user wants to know which product is performing best. I should first check what sheets are available, then read the sales data to compare products."
+              },
+              { "type": "toolCall", "id": "tc_t1", "name": "get_sheets_metadata", "arguments": {} }
+            ],
+            "stopReason": "toolUse",
+            "usage": { "input": 950, "output": 60 }
+          }
+        },
+        {
+          "type": "tool_execution_start",
+          "toolCallId": "tc_t1",
+          "toolName": "get_sheets_metadata",
+          "args": {},
+          "delay": 100
+        },
+        {
+          "type": "tool_execution_end",
+          "toolCallId": "tc_t1",
+          "toolName": "get_sheets_metadata",
+          "result": {
+            "content": [
+              {
+                "type": "text",
+                "text": "[\n  { \"name\": \"Sales\", \"rows\": 4, \"columns\": 6 },\n  { \"name\": \"Inventory\", \"rows\": 4, \"columns\": 4 },\n  { \"name\": \"Summary\", \"rows\": 0, \"columns\": 0 }\n]"
+              }
+            ]
+          },
+          "isError": false,
+          "delay": 300
+        },
+        { "type": "turn_start", "delay": 200 },
+        {
+          "type": "turn_end",
+          "delay": 100,
+          "message": {
+            "content": [
+              {
+                "type": "thinking",
+                "thinking": "Good, the Sales sheet has 4 rows and 6 columns. Let me read the full data to analyze product performance across all quarters."
+              },
+              {
+                "type": "toolCall",
+                "id": "tc_t2",
+                "name": "get_cell_ranges",
+                "arguments": { "sheetName": "Sales", "ranges": ["A1:F4"] }
+              }
+            ],
+            "stopReason": "toolUse",
+            "usage": { "input": 1300, "output": 70 }
+          }
+        },
+        {
+          "type": "tool_execution_start",
+          "toolCallId": "tc_t2",
+          "toolName": "get_cell_ranges",
+          "args": { "sheetName": "Sales", "ranges": ["A1:F4"] },
+          "delay": 100
+        },
+        {
+          "type": "tool_execution_end",
+          "toolCallId": "tc_t2",
+          "toolName": "get_cell_ranges",
+          "result": {
+            "content": [
+              {
+                "type": "text",
+                "text": "{\n  \"success\": true,\n  \"worksheet\": {\n    \"name\": \"Sales\",\n    \"cells\": {\n      \"A1\": { \"value\": \"Product\" }, \"B1\": { \"value\": \"Q1 Sales\" }, \"C1\": { \"value\": \"Q2 Sales\" }, \"D1\": { \"value\": \"Q3 Sales\" }, \"E1\": { \"value\": \"Q4 Sales\" }, \"F1\": { \"value\": \"Total\" },\n      \"A2\": { \"value\": \"Widget A\" }, \"B2\": { \"value\": 12500 }, \"C2\": { \"value\": 14200 }, \"D2\": { \"value\": 11800 }, \"E2\": { \"value\": 16300 }, \"F2\": { \"formula\": \"=SUM(B2:E2)\", \"value\": 54800 },\n      \"A3\": { \"value\": \"Widget B\" }, \"B3\": { \"value\": 8900 }, \"C3\": { \"value\": 9200 }, \"D3\": { \"value\": 10100 }, \"E3\": { \"value\": 11500 }, \"F3\": { \"formula\": \"=SUM(B3:E3)\", \"value\": 39700 },\n      \"A4\": { \"value\": \"Widget C\" }, \"B4\": { \"value\": 5600 }, \"C4\": { \"value\": 6100 }, \"D4\": { \"value\": 7200 }, \"E4\": { \"value\": 8400 }, \"F4\": { \"formula\": \"=SUM(B4:E4)\", \"value\": 27300 }\n    }\n  }\n}"
+              }
+            ]
+          },
+          "isError": false,
+          "delay": 600
+        },
+        { "type": "turn_start", "delay": 200 },
+        {
+          "type": "turn_end",
+          "delay": 400,
+          "message": {
+            "content": [
+              {
+                "type": "thinking",
+                "thinking": "Let me analyze the data:\n\nWidget A: Q1=12500, Q2=14200, Q3=11800, Q4=16300, Total=54800\nWidget B: Q1=8900, Q2=9200, Q3=10100, Q4=11500, Total=39700\nWidget C: Q1=5600, Q2=6100, Q3=7200, Q4=8400, Total=27300\n\nWidget A clearly has the highest total at $54,800. It also has the highest individual quarter (Q4 at $16,300).\n\nBut looking at growth trends:\n- Widget A: Q1->Q4 growth = (16300-12500)/12500 = 30.4%\n- Widget B: Q1->Q4 growth = (11500-8900)/8900 = 29.2%\n- Widget C: Q1->Q4 growth = (8400-5600)/5600 = 50.0%\n\nWidget C has the highest growth rate even though its absolute numbers are lowest. That's worth noting.\n\nI should present both the absolute leader (Widget A) and the growth leader (Widget C) to give a complete picture."
+              },
+              {
+                "type": "text",
+                "text": "Based on the Sales data, here's the performance analysis:\n\n**Overall Leader: Widget A** with **$54,800** in total sales\n\n| Product | Total Sales | Q1-Q4 Growth |\n|---------|------------|-------------|\n| Widget A | $54,800 | +30.4% |\n| Widget B | $39,700 | +29.2% |\n| Widget C | $27,300 | **+50.0%** |\n\nKey insights:\n- **Widget A** dominates in absolute revenue, accounting for 45% of total sales\n- **Widget C** is the fastest growing product (+50% Q1 to Q4), despite having the lowest absolute numbers\n- All products show positive growth trends quarter-over-quarter\n\nWidget C's rapid growth makes it worth monitoring — it could overtake Widget B within the next few quarters."
+              }
+            ],
+            "stopReason": "stop",
+            "usage": { "input": 2200, "output": 280 }
+          }
+        }
+      ]
+    },
+    {
+      "userMessage": "Create a summary of inventory levels with a recommendation",
+      "events": [
+        { "type": "turn_start", "delay": 200 },
+        {
+          "type": "turn_end",
+          "delay": 100,
+          "message": {
+            "content": [
+              {
+                "type": "thinking",
+                "thinking": "I need to cross-reference sales data with inventory to give a meaningful recommendation. Let me read the inventory sheet. I already have the sales data from the previous turns. I should calculate the sell-through rate and recommend restocking for items with low inventory relative to their sales velocity."
+              },
+              {
+                "type": "toolCall",
+                "id": "tc_t3",
+                "name": "get_cell_ranges",
+                "arguments": { "sheetName": "Inventory", "ranges": ["A1:D4"] }
+              }
+            ],
+            "stopReason": "toolUse",
+            "usage": { "input": 2800, "output": 65 }
+          }
+        },
+        {
+          "type": "tool_execution_start",
+          "toolCallId": "tc_t3",
+          "toolName": "get_cell_ranges",
+          "args": { "sheetName": "Inventory", "ranges": ["A1:D4"] },
+          "delay": 100
+        },
+        {
+          "type": "tool_execution_end",
+          "toolCallId": "tc_t3",
+          "toolName": "get_cell_ranges",
+          "result": {
+            "content": [
+              {
+                "type": "text",
+                "text": "{\n  \"cells\": {\n    \"A1\": { \"value\": \"Item\" }, \"B1\": { \"value\": \"SKU\" }, \"C1\": { \"value\": \"Quantity\" }, \"D1\": { \"value\": \"Location\" },\n    \"A2\": { \"value\": \"Widget A\" }, \"B2\": { \"value\": \"WA-001\" }, \"C2\": { \"value\": 342 }, \"D2\": { \"value\": \"Warehouse 1\" },\n    \"A3\": { \"value\": \"Widget B\" }, \"B3\": { \"value\": \"WB-002\" }, \"C3\": { \"value\": 128 }, \"D3\": { \"value\": \"Warehouse 2\" },\n    \"A4\": { \"value\": \"Widget C\" }, \"B4\": { \"value\": \"WC-003\" }, \"C4\": { \"value\": 56 }, \"D4\": { \"value\": \"Warehouse 1\" }\n  }\n}"
+              }
+            ]
+          },
+          "isError": false,
+          "delay": 400
+        },
+        { "type": "turn_start", "delay": 200 },
+        {
+          "type": "turn_end",
+          "delay": 500,
+          "message": {
+            "content": [
+              {
+                "type": "thinking",
+                "thinking": "Now let me cross-reference:\n\nWidget A: 342 units in stock, Q4 sales of 16,300 (highest quarter)\nWidget B: 128 units in stock, Q4 sales of 11,500\nWidget C: 56 units in stock, Q4 sales of 8,400 (fastest growing)\n\nThe sales numbers are in dollars, not units, so I can't directly calculate days of inventory. But I can note the relative positions:\n- Widget C has the lowest inventory (56 units) AND the fastest growth rate (50%). This is the most at-risk for stockouts.\n- Widget B has moderate inventory (128) with moderate growth.\n- Widget A has the most inventory (342) and the highest sales, but lower growth rate.\n\nI should recommend prioritizing Widget C restocking given its growth trajectory and low stock level."
+              },
+              {
+                "type": "text",
+                "text": "Here's the inventory-to-sales cross-reference:\n\n| Product | Current Stock | Q4 Sales | Growth Rate | Risk |\n|---------|--------------|----------|------------|------|\n| Widget A | 342 units | $16,300 | +30.4% | Low |\n| Widget B | 128 units | $11,500 | +29.2% | Medium |\n| Widget C | **56 units** | $8,400 | **+50.0%** | **High** |\n\n**Recommendation:**\n\n1. **Urgent: Restock Widget C** — Only 56 units remain with a 50% quarterly growth rate. At this trajectory, demand will outpace supply within the next quarter.\n\n2. **Monitor Widget B** — 128 units with steady ~29% growth. Schedule a reorder within 4-6 weeks.\n\n3. **Widget A is healthy** — 342 units provides adequate buffer despite highest absolute sales volume.\n\nWould you like me to write this summary to the Summary sheet?"
+              }
+            ],
+            "stopReason": "stop",
+            "usage": { "input": 3200, "output": 320 }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/mock/fixtures/tool-calls.json
+++ b/src/mock/fixtures/tool-calls.json
@@ -1,0 +1,270 @@
+{
+  "name": "Tool Calls",
+  "description": "Tool calls with mixed success/error results and tool grouping",
+  "autoPlay": true,
+  "streamDelay": 800,
+  "turns": [
+    {
+      "userMessage": "Show me all sheets in the workbook",
+      "events": [
+        { "type": "turn_start", "delay": 200 },
+        {
+          "type": "turn_end",
+          "delay": 100,
+          "message": {
+            "content": [
+              { "type": "toolCall", "id": "tc_1", "name": "get_sheets_metadata", "arguments": {} }
+            ],
+            "stopReason": "toolUse",
+            "usage": { "input": 900, "output": 45 }
+          }
+        },
+        {
+          "type": "tool_execution_start",
+          "toolCallId": "tc_1",
+          "toolName": "get_sheets_metadata",
+          "args": {},
+          "delay": 100
+        },
+        {
+          "type": "tool_execution_end",
+          "toolCallId": "tc_1",
+          "toolName": "get_sheets_metadata",
+          "result": {
+            "content": [
+              {
+                "type": "text",
+                "text": "[\n  { \"id\": \"Sales\", \"name\": \"Sales\", \"rows\": 4, \"columns\": 6 },\n  { \"id\": \"Inventory\", \"name\": \"Inventory\", \"rows\": 4, \"columns\": 4 },\n  { \"id\": \"Summary\", \"name\": \"Summary\", \"rows\": 0, \"columns\": 0 }\n]"
+              }
+            ]
+          },
+          "isError": false,
+          "delay": 400
+        },
+        { "type": "turn_start", "delay": 200 },
+        {
+          "type": "turn_end",
+          "delay": 300,
+          "message": {
+            "content": [
+              {
+                "type": "text",
+                "text": "Your workbook has **3 sheets**:\n\n1. **Sales** - 4 rows x 6 columns of data\n2. **Inventory** - 4 rows x 4 columns of data\n3. **Summary** - Empty sheet\n\nWhat would you like to do?"
+              }
+            ],
+            "stopReason": "stop",
+            "usage": { "input": 1100, "output": 80 }
+          }
+        }
+      ]
+    },
+    {
+      "userMessage": "Read cells A1:C3 from the Sales sheet",
+      "events": [
+        { "type": "turn_start", "delay": 150 },
+        {
+          "type": "turn_end",
+          "delay": 100,
+          "message": {
+            "content": [
+              {
+                "type": "toolCall",
+                "id": "tc_2",
+                "name": "get_cell_ranges",
+                "arguments": { "sheetName": "Sales", "ranges": ["A1:C3"] }
+              }
+            ],
+            "stopReason": "toolUse",
+            "usage": { "input": 1200, "output": 55 }
+          }
+        },
+        {
+          "type": "tool_execution_start",
+          "toolCallId": "tc_2",
+          "toolName": "get_cell_ranges",
+          "args": { "sheetName": "Sales", "ranges": ["A1:C3"] },
+          "delay": 100
+        },
+        {
+          "type": "tool_execution_end",
+          "toolCallId": "tc_2",
+          "toolName": "get_cell_ranges",
+          "result": {
+            "content": [
+              {
+                "type": "text",
+                "text": "{\n  \"success\": true,\n  \"worksheet\": {\n    \"name\": \"Sales\",\n    \"dimension\": { \"rows\": 4, \"columns\": 6 },\n    \"cells\": {\n      \"A1\": { \"value\": \"Product\" },\n      \"B1\": { \"value\": \"Q1 Sales\" },\n      \"C1\": { \"value\": \"Q2 Sales\" },\n      \"A2\": { \"value\": \"Widget A\" },\n      \"B2\": { \"value\": 12500 },\n      \"C2\": { \"value\": 14200 },\n      \"A3\": { \"value\": \"Widget B\" },\n      \"B3\": { \"value\": 8900 },\n      \"C3\": { \"value\": 9200 }\n    }\n  }\n}"
+              }
+            ]
+          },
+          "isError": false,
+          "delay": 500
+        },
+        { "type": "turn_start", "delay": 200 },
+        {
+          "type": "turn_end",
+          "delay": 300,
+          "message": {
+            "content": [
+              {
+                "type": "text",
+                "text": "Here's the data from **Sales A1:C3**:\n\n| Product | Q1 Sales | Q2 Sales |\n|---------|----------|----------|\n| Widget A | 12,500 | 14,200 |\n| Widget B | 8,900 | 9,200 |\n\nWidget A is outperforming Widget B in both quarters."
+              }
+            ],
+            "stopReason": "stop",
+            "usage": { "input": 1600, "output": 110 }
+          }
+        }
+      ]
+    },
+    {
+      "userMessage": "Format the header row with bold and blue background",
+      "events": [
+        { "type": "turn_start", "delay": 150 },
+        {
+          "type": "turn_end",
+          "delay": 100,
+          "message": {
+            "content": [
+              {
+                "type": "toolCall",
+                "id": "tc_3",
+                "name": "execute_office_js",
+                "arguments": {
+                  "code": "const sheet = context.workbook.worksheets.getItem('Sales');\nconst header = sheet.getRange('A1:F1');\nheader.format.font.bold = true;\nheader.format.fill.color = '#4472C4';\nheader.format.font.color = '#FFFFFF';\nawait context.sync();\nreturn { success: true };"
+                }
+              }
+            ],
+            "stopReason": "toolUse",
+            "usage": { "input": 1400, "output": 90 }
+          }
+        },
+        {
+          "type": "tool_execution_start",
+          "toolCallId": "tc_3",
+          "toolName": "execute_office_js",
+          "args": { "code": "..." },
+          "delay": 100
+        },
+        {
+          "type": "tool_execution_end",
+          "toolCallId": "tc_3",
+          "toolName": "execute_office_js",
+          "result": {
+            "content": [
+              {
+                "type": "text",
+                "text": "Error: RichApi.Error - The operation failed because the requested range overlaps with a table.\n\nStack:\nError: RichApi.Error\n    at processErrors (office.js:1234)\n    at Excel.RequestContext._processResult (office.js:5678)"
+              }
+            ]
+          },
+          "isError": true,
+          "delay": 600
+        },
+        { "type": "turn_start", "delay": 200 },
+        {
+          "type": "turn_end",
+          "delay": 300,
+          "message": {
+            "content": [
+              {
+                "type": "text",
+                "text": "The formatting failed because the range overlaps with an existing Excel table. Let me try a different approach by modifying the table style instead."
+              }
+            ],
+            "stopReason": "stop",
+            "errorMessage": "Tool execution failed",
+            "usage": { "input": 1800, "output": 45 }
+          }
+        }
+      ]
+    },
+    {
+      "userMessage": "Write some totals and clear the summary sheet",
+      "events": [
+        { "type": "turn_start", "delay": 150 },
+        {
+          "type": "turn_end",
+          "delay": 100,
+          "message": {
+            "content": [
+              {
+                "type": "toolCall",
+                "id": "tc_4",
+                "name": "set_cell_range",
+                "arguments": {
+                  "sheetName": "Sales",
+                  "cells": {
+                    "A5": { "value": "Total" },
+                    "B5": { "formula": "=SUM(B2:B4)" },
+                    "C5": { "formula": "=SUM(C2:C4)" }
+                  }
+                }
+              },
+              {
+                "type": "toolCall",
+                "id": "tc_5",
+                "name": "clear_cell_range",
+                "arguments": {
+                  "sheetName": "Summary",
+                  "range": "A1:Z100"
+                }
+              }
+            ],
+            "stopReason": "toolUse",
+            "usage": { "input": 1500, "output": 120 }
+          }
+        },
+        {
+          "type": "tool_execution_start",
+          "toolCallId": "tc_4",
+          "toolName": "set_cell_range",
+          "args": {},
+          "delay": 50
+        },
+        {
+          "type": "tool_execution_end",
+          "toolCallId": "tc_4",
+          "toolName": "set_cell_range",
+          "result": {
+            "content": [{ "type": "text", "text": "{ \"success\": true }" }]
+          },
+          "isError": false,
+          "delay": 200
+        },
+        {
+          "type": "tool_execution_start",
+          "toolCallId": "tc_5",
+          "toolName": "clear_cell_range",
+          "args": {},
+          "delay": 50
+        },
+        {
+          "type": "tool_execution_end",
+          "toolCallId": "tc_5",
+          "toolName": "clear_cell_range",
+          "result": {
+            "content": [{ "type": "text", "text": "{ \"success\": true }" }]
+          },
+          "isError": false,
+          "delay": 200
+        },
+        { "type": "turn_start", "delay": 200 },
+        {
+          "type": "turn_end",
+          "delay": 300,
+          "message": {
+            "content": [
+              {
+                "type": "text",
+                "text": "Done! I've:\n\n1. Added a **Total** row at A5 with SUM formulas for Q1 and Q2\n2. Cleared the Summary sheet completely\n\nThe totals will auto-update when you change the source data."
+              }
+            ],
+            "stopReason": "stop",
+            "usage": { "input": 1900, "output": 65 }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/mock/index.html
+++ b/src/mock/index.html
@@ -4,9 +4,76 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>OpenExcel - Mock UI</title>
+    <style>
+      html {
+        display: flex;
+        justify-content: center;
+        min-height: 100vh;
+        background: #f0f0f0;
+      }
+      body {
+        width: 380px;
+        min-height: 100vh;
+        border-left: 1px solid #d0d0d0;
+        border-right: 1px solid #d0d0d0;
+        background: #ffffff;
+        position: relative;
+      }
+      .resize-handle {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        width: 8px;
+        cursor: col-resize;
+        z-index: 10000;
+      }
+      .resize-handle:hover,
+      .resize-handle.active {
+        background: rgba(0, 120, 212, 0.35);
+      }
+      .resize-handle-left { left: -4px; }
+      .resize-handle-right { right: -4px; }
+      html.resizing { cursor: col-resize; }
+      html.resizing * { cursor: col-resize !important; }
+    </style>
   </head>
   <body>
+    <div class="resize-handle resize-handle-left"></div>
+    <div class="resize-handle resize-handle-right"></div>
     <div id="root">Loading mock UI...</div>
     <script type="module" src="./mockMain.tsx"></script>
+    <script>
+      (function() {
+        const body = document.body;
+        const html = document.documentElement;
+        const minW = 280, maxW = 800;
+        let dragging = null, startX = 0, startW = 0;
+
+        for (const handle of document.querySelectorAll('.resize-handle')) {
+          handle.addEventListener('mousedown', function(e) {
+            e.preventDefault();
+            dragging = this.classList.contains('resize-handle-left') ? 'left' : 'right';
+            startX = e.clientX;
+            startW = body.offsetWidth;
+            this.classList.add('active');
+            html.classList.add('resizing');
+          });
+        }
+
+        document.addEventListener('mousemove', function(e) {
+          if (!dragging) return;
+          const dx = e.clientX - startX;
+          const delta = dragging === 'right' ? dx * 2 : -dx * 2;
+          body.style.width = Math.max(minW, Math.min(maxW, startW + delta)) + 'px';
+        });
+
+        document.addEventListener('mouseup', function() {
+          if (!dragging) return;
+          dragging = null;
+          html.classList.remove('resizing');
+          for (const h of document.querySelectorAll('.resize-handle')) h.classList.remove('active');
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/src/mock/index.html
+++ b/src/mock/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OpenExcel - Mock UI</title>
+  </head>
+  <body>
+    <div id="root">Loading mock UI...</div>
+    <script type="module" src="./mockMain.tsx"></script>
+  </body>
+</html>

--- a/src/mock/mockAgentDriver.ts
+++ b/src/mock/mockAgentDriver.ts
@@ -1,0 +1,274 @@
+import type { AgentEvent, AgentMessage } from "@mariozechner/pi-agent-core";
+import type {
+  AssistantMessage,
+  TextContent,
+  ThinkingContent,
+  ToolCall,
+  ToolResultMessage,
+  UserMessage,
+} from "@mariozechner/pi-ai";
+
+export type MockToolResultContent =
+  | { type: "text"; text: string }
+  | { type: "image"; data: string; mimeType: string };
+
+export type MockEventDef =
+  | { type: "turn_start"; delay?: number }
+  | {
+      type: "turn_end";
+      delay?: number;
+      message: {
+        content: Array<
+          | { type: "text"; text: string }
+          | { type: "thinking"; thinking: string }
+          | { type: "toolCall"; id: string; name: string; arguments: Record<string, unknown> }
+        >;
+        stopReason?: "stop" | "length" | "toolUse" | "error" | "aborted";
+        errorMessage?: string;
+        usage?: { input: number; output: number };
+      };
+    }
+  | {
+      type: "tool_execution_start";
+      toolCallId?: string;
+      toolName: string;
+      args?: Record<string, unknown>;
+      delay?: number;
+    }
+  | {
+      type: "tool_execution_end";
+      toolCallId?: string;
+      toolName: string;
+      result: { content: MockToolResultContent[] };
+      isError: boolean;
+      delay?: number;
+    };
+
+export type MockTurn = {
+  userMessage: string;
+  events: MockEventDef[];
+};
+
+export type MockScenario = {
+  name: string;
+  description: string;
+  autoPlay?: boolean;
+  streamDelay?: number;
+  turns: MockTurn[];
+};
+
+function makeUsage(input = 0, output = 0) {
+  return {
+    input,
+    output,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: input + output,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  };
+}
+
+function buildAssistantMessage(
+  def: Extract<MockEventDef, { type: "turn_end" }>["message"],
+): AssistantMessage {
+  const content: (TextContent | ThinkingContent | ToolCall)[] = def.content.map((block) => {
+    if (block.type === "text") return { type: "text" as const, text: block.text };
+    if (block.type === "thinking") return { type: "thinking" as const, thinking: block.thinking };
+    return {
+      type: "toolCall" as const,
+      id: block.id,
+      name: block.name,
+      arguments: block.arguments,
+    };
+  });
+
+  return {
+    role: "assistant",
+    content,
+    api: "openai-completions",
+    provider: "mock",
+    model: "mock-model",
+    usage: makeUsage(def.usage?.input, def.usage?.output),
+    stopReason: def.stopReason ?? "stop",
+    errorMessage: def.errorMessage,
+    timestamp: uniqueTimestamp(),
+  };
+}
+
+function buildToolResultMessage(
+  def: Extract<MockEventDef, { type: "tool_execution_end" }>,
+): ToolResultMessage {
+  return {
+    role: "toolResult",
+    toolCallId: def.toolCallId ?? `mock-tc-${def.toolName}`,
+    toolName: def.toolName,
+    content: def.result.content.map((c) => {
+      if (c.type === "text") return { type: "text" as const, text: c.text };
+      return { type: "image" as const, data: c.data, mimeType: c.mimeType };
+    }),
+    isError: def.isError,
+    timestamp: uniqueTimestamp(),
+  };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+let timestampCounter = 0;
+
+function uniqueTimestamp(): number {
+  timestampCounter += 1;
+  return Date.now() + timestampCounter;
+}
+
+type AgentLikeState = {
+  messages: AgentMessage[];
+  isStreaming: boolean;
+};
+
+export class MockAgentDriver {
+  state: AgentLikeState = {
+    messages: [],
+    isStreaming: false,
+  };
+
+  private listeners: Set<(event: AgentEvent) => void> = new Set();
+  private scenario: MockScenario | null = null;
+  private turnIndex = 0;
+  private aborted = false;
+  private autoPlayTimer: ReturnType<typeof setTimeout> | null = null;
+
+  subscribe(handler: (event: AgentEvent) => void): () => void {
+    this.listeners.add(handler);
+    return () => {
+      this.listeners.delete(handler);
+    };
+  }
+
+  private emit(event: AgentEvent) {
+    for (const listener of this.listeners) {
+      listener(event);
+    }
+  }
+
+  loadScenario(scenario: MockScenario) {
+    this.reset();
+    this.scenario = scenario;
+    this.turnIndex = 0;
+  }
+
+  async prompt(text: string | AgentMessage | AgentMessage[]): Promise<void> {
+    const userText = typeof text === "string" ? text : "";
+    if (!this.scenario) return;
+
+    const turn = this.scenario.turns[this.turnIndex];
+    if (!turn) return;
+
+    this.turnIndex += 1;
+    this.aborted = false;
+    this.state.isStreaming = true;
+
+    // Add user message
+    const userMsg: UserMessage = {
+      role: "user",
+      content: userText,
+      timestamp: uniqueTimestamp(),
+    };
+    this.state.messages = [...this.state.messages, userMsg];
+
+    // Emit agent_start
+    this.emit({ type: "agent_start" });
+
+    // Replay events
+    for (const eventDef of turn.events) {
+      if (this.aborted) break;
+
+      if (eventDef.delay) {
+        await sleep(eventDef.delay);
+      }
+      if (this.aborted) break;
+
+      switch (eventDef.type) {
+        case "turn_start": {
+          this.emit({ type: "turn_start" });
+          break;
+        }
+        case "turn_end": {
+          const assistantMsg = buildAssistantMessage(eventDef.message);
+          this.state.messages = [...this.state.messages, assistantMsg];
+          this.emit({
+            type: "turn_end",
+            message: assistantMsg,
+            toolResults: [],
+          });
+          break;
+        }
+        case "tool_execution_start": {
+          this.emit({
+            type: "tool_execution_start",
+            toolCallId: eventDef.toolCallId ?? `mock-tc-${eventDef.toolName}`,
+            toolName: eventDef.toolName,
+            args: eventDef.args ?? {},
+          });
+          break;
+        }
+        case "tool_execution_end": {
+          const toolResult = buildToolResultMessage(eventDef);
+          this.state.messages = [...this.state.messages, toolResult];
+          this.emit({
+            type: "tool_execution_end",
+            toolCallId: eventDef.toolCallId ?? `mock-tc-${eventDef.toolName}`,
+            toolName: eventDef.toolName,
+            result: eventDef.result,
+            isError: eventDef.isError,
+          });
+          break;
+        }
+      }
+    }
+
+    // Emit agent_end
+    this.state.isStreaming = false;
+    this.emit({
+      type: "agent_end",
+      messages: this.state.messages,
+    });
+  }
+
+  abort() {
+    this.aborted = true;
+    this.state.isStreaming = false;
+    if (this.autoPlayTimer) {
+      clearTimeout(this.autoPlayTimer);
+      this.autoPlayTimer = null;
+    }
+  }
+
+  reset() {
+    this.abort();
+    this.state.messages = [];
+    this.state.isStreaming = false;
+    this.turnIndex = 0;
+  }
+
+  get currentTurnIndex(): number {
+    return this.turnIndex;
+  }
+
+  get totalTurns(): number {
+    return this.scenario?.turns.length ?? 0;
+  }
+
+  get hasNextTurn(): boolean {
+    return this.scenario != null && this.turnIndex < this.scenario.turns.length;
+  }
+
+  promptNextTurn(): void {
+    if (!this.scenario || !this.hasNextTurn) return;
+    const turn = this.scenario.turns[this.turnIndex];
+    if (turn) {
+      void this.prompt(turn.userMessage);
+    }
+  }
+}

--- a/src/mock/mockMain.tsx
+++ b/src/mock/mockMain.tsx
@@ -1,0 +1,20 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { MockWorkbenchPage } from "./MockWorkbenchPage";
+import "../styles/index.css";
+
+function renderApp() {
+  const rootElement = document.getElementById("root");
+
+  if (!rootElement) {
+    throw new Error("Unable to find the application root element.");
+  }
+
+  createRoot(rootElement).render(
+    <StrictMode>
+      <MockWorkbenchPage />
+    </StrictMode>,
+  );
+}
+
+renderApp();

--- a/src/mock/mockWorkbookAdapter.ts
+++ b/src/mock/mockWorkbookAdapter.ts
@@ -1,0 +1,254 @@
+import type { WorkbookAdapter } from "../lib/adapters/types";
+import type {
+  ClearCellRangeInput,
+  GetCellRangesInput,
+  GetCellRangesOutput,
+  GetRangeImageInput,
+  GetRangeImageOutput,
+  SetCellRangeInput,
+  SheetMetadata,
+  WorkbookCell,
+  WorkbookPreview,
+} from "../lib/types/workbook";
+
+// 1x1 transparent PNG as base64
+const PLACEHOLDER_PNG =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQI12NgAAIABQABNjN9GQAAAABJRUEFTkSuQmCC";
+
+type SheetData = {
+  name: string;
+  cells: Record<string, WorkbookCell>;
+};
+
+function defaultSheets(): Map<string, SheetData> {
+  const sheets = new Map<string, SheetData>();
+
+  const salesCells: Record<string, WorkbookCell> = {
+    A1: { value: "Product" },
+    B1: { value: "Q1 Sales" },
+    C1: { value: "Q2 Sales" },
+    D1: { value: "Q3 Sales" },
+    E1: { value: "Q4 Sales" },
+    F1: { value: "Total" },
+    A2: { value: "Widget A" },
+    B2: { value: 12500 },
+    C2: { value: 14200 },
+    D2: { value: 11800 },
+    E2: { value: 16300 },
+    F2: { formula: "=SUM(B2:E2)", value: 54800 },
+    A3: { value: "Widget B" },
+    B3: { value: 8900 },
+    C3: { value: 9200 },
+    D3: { value: 10100 },
+    E3: { value: 11500 },
+    F3: { formula: "=SUM(B3:E3)", value: 39700 },
+    A4: { value: "Widget C" },
+    B4: { value: 5600 },
+    C4: { value: 6100 },
+    D4: { value: 7200 },
+    E4: { value: 8400 },
+    F4: { formula: "=SUM(B4:E4)", value: 27300 },
+  };
+  sheets.set("Sales", { name: "Sales", cells: salesCells });
+
+  const inventoryCells: Record<string, WorkbookCell> = {
+    A1: { value: "Item" },
+    B1: { value: "SKU" },
+    C1: { value: "Quantity" },
+    D1: { value: "Location" },
+    A2: { value: "Widget A" },
+    B2: { value: "WA-001" },
+    C2: { value: 342 },
+    D2: { value: "Warehouse 1" },
+    A3: { value: "Widget B" },
+    B3: { value: "WB-002" },
+    C3: { value: 128 },
+    D3: { value: "Warehouse 2" },
+    A4: { value: "Widget C" },
+    B4: { value: "WC-003" },
+    C4: { value: 56 },
+    D4: { value: "Warehouse 1" },
+  };
+  sheets.set("Inventory", { name: "Inventory", cells: inventoryCells });
+
+  sheets.set("Summary", { name: "Summary", cells: {} });
+
+  return sheets;
+}
+
+function columnLetter(col: number): string {
+  let result = "";
+  let c = col;
+  while (c > 0) {
+    c -= 1;
+    result = String.fromCharCode(65 + (c % 26)) + result;
+    c = Math.floor(c / 26);
+  }
+  return result;
+}
+
+function parseA1(address: string): { row: number; col: number } | null {
+  const match = /^([A-Z]+)(\d+)$/i.exec(address.trim());
+  if (!match?.[1] || !match[2]) return null;
+  const letters = match[1].toUpperCase();
+  const row = Number.parseInt(match[2], 10);
+  let col = 0;
+  for (let i = 0; i < letters.length; i++) {
+    col = col * 26 + (letters.charCodeAt(i) - 64);
+  }
+  return { row, col };
+}
+
+function getDimensions(cells: Record<string, WorkbookCell>): { rows: number; columns: number } {
+  let maxRow = 0;
+  let maxCol = 0;
+  for (const address of Object.keys(cells)) {
+    const parsed = parseA1(address);
+    if (parsed) {
+      maxRow = Math.max(maxRow, parsed.row);
+      maxCol = Math.max(maxCol, parsed.col);
+    }
+  }
+  return { rows: maxRow, columns: maxCol };
+}
+
+export class MockWorkbookAdapter implements WorkbookAdapter {
+  readonly kind = "office" as const;
+  readonly label = "Mock Workbook";
+
+  private sheets: Map<string, SheetData>;
+
+  constructor() {
+    this.sheets = defaultSheets();
+  }
+
+  async getSheetsMetadata(): Promise<SheetMetadata[]> {
+    const result: SheetMetadata[] = [];
+    for (const sheet of this.sheets.values()) {
+      const dim = getDimensions(sheet.cells);
+      result.push({
+        id: sheet.name,
+        name: sheet.name,
+        rows: dim.rows,
+        columns: dim.columns,
+      });
+    }
+    return result;
+  }
+
+  async getCellRanges(input: GetCellRangesInput): Promise<GetCellRangesOutput> {
+    const sheet = this.sheets.get(input.sheetName);
+    if (!sheet) {
+      throw new Error(`Sheet "${input.sheetName}" not found`);
+    }
+
+    const cells: Record<string, WorkbookCell> = {};
+    for (const rangeAddress of input.ranges) {
+      const parts = rangeAddress.split(":");
+      if (parts.length === 1) {
+        const addr = (parts[0] ?? "").toUpperCase();
+        if (sheet.cells[addr]) {
+          cells[addr] = sheet.cells[addr];
+        }
+      } else {
+        const start = parseA1(parts[0] ?? "");
+        const end = parseA1(parts[1] ?? "");
+        if (start && end) {
+          for (let r = start.row; r <= end.row; r++) {
+            for (let c = start.col; c <= end.col; c++) {
+              const addr = `${columnLetter(c)}${r}`;
+              cells[addr] = sheet.cells[addr] ?? {};
+            }
+          }
+        }
+      }
+    }
+
+    const dim = getDimensions(sheet.cells);
+    return {
+      success: true,
+      worksheet: {
+        name: input.sheetName,
+        dimension: dim,
+        cells,
+      },
+    };
+  }
+
+  async getRangeImage(_input: GetRangeImageInput): Promise<GetRangeImageOutput> {
+    return {
+      success: true,
+      worksheet: { name: _input.sheetName },
+      range: _input.range,
+      mimeType: "image/png",
+      imageBase64: PLACEHOLDER_PNG,
+    };
+  }
+
+  async setCellRange(input: SetCellRangeInput): Promise<{ success: true }> {
+    let sheet = this.sheets.get(input.sheetName);
+    if (!sheet) {
+      sheet = { name: input.sheetName, cells: {} };
+      this.sheets.set(input.sheetName, sheet);
+    }
+
+    for (const [address, cell] of Object.entries(input.cells)) {
+      sheet.cells[address.toUpperCase()] = { ...cell };
+    }
+    return { success: true };
+  }
+
+  async clearCellRange(input: ClearCellRangeInput): Promise<{ success: true }> {
+    const sheet = this.sheets.get(input.sheetName);
+    if (!sheet) return { success: true };
+
+    const parts = input.range.split(":");
+    if (parts.length === 2) {
+      const start = parseA1(parts[0] ?? "");
+      const end = parseA1(parts[1] ?? "");
+      if (start && end) {
+        for (let r = start.row; r <= end.row; r++) {
+          for (let c = start.col; c <= end.col; c++) {
+            const addr = `${columnLetter(c)}${r}`;
+            delete sheet.cells[addr];
+          }
+        }
+      }
+    }
+    return { success: true };
+  }
+
+  async executeOfficeJs(_code: string): Promise<unknown> {
+    return { success: true, note: "Mock: Office.js execution simulated" };
+  }
+
+  async getPreview(sheetName?: string): Promise<WorkbookPreview> {
+    const targetName = sheetName ?? this.sheets.keys().next().value ?? "Sheet1";
+    const sheet = this.sheets.get(targetName);
+    const sheetNames = [...this.sheets.keys()];
+
+    if (!sheet) {
+      return { rows: [], sheetName: targetName, sheets: sheetNames };
+    }
+
+    const dim = getDimensions(sheet.cells);
+    const maxRow = Math.min(dim.rows, 12);
+    const maxCol = Math.min(dim.columns, 6);
+
+    const rows: WorkbookPreview["rows"] = [];
+    for (let r = 1; r <= maxRow; r++) {
+      const cellsArr: Array<{ id: string; value: string }> = [];
+      for (let c = 1; c <= maxCol; c++) {
+        const addr = `${columnLetter(c)}${r}`;
+        const cell = sheet.cells[addr];
+        cellsArr.push({
+          id: addr,
+          value: cell?.value != null ? String(cell.value) : "",
+        });
+      }
+      rows.push({ id: `row-${r}`, cells: cellsArr });
+    }
+
+    return { rows, sheetName: targetName, sheets: sheetNames };
+  }
+}

--- a/src/mock/mockWorkbookAdapter.ts
+++ b/src/mock/mockWorkbookAdapter.ts
@@ -203,7 +203,10 @@ export class MockWorkbookAdapter implements WorkbookAdapter {
     if (!sheet) return { success: true };
 
     const parts = input.range.split(":");
-    if (parts.length === 2) {
+    if (parts.length === 1) {
+      const addr = (parts[0] ?? "").toUpperCase();
+      delete sheet.cells[addr];
+    } else {
       const start = parseA1(parts[0] ?? "");
       const end = parseA1(parts[1] ?? "");
       if (start && end) {

--- a/src/mock/scenarioLoader.ts
+++ b/src/mock/scenarioLoader.ts
@@ -1,0 +1,18 @@
+import basicChat from "./fixtures/basic-chat.json";
+import errorStates from "./fixtures/error-states.json";
+import streamingSlow from "./fixtures/streaming-slow.json";
+import thinking from "./fixtures/thinking.json";
+import toolCalls from "./fixtures/tool-calls.json";
+import type { MockScenario } from "./mockAgentDriver";
+
+export const ALL_SCENARIOS: MockScenario[] = [
+  basicChat as MockScenario,
+  toolCalls as MockScenario,
+  thinking as MockScenario,
+  streamingSlow as MockScenario,
+  errorStates as MockScenario,
+];
+
+export function getScenarioByName(name: string): MockScenario | undefined {
+  return ALL_SCENARIOS.find((s) => s.name === name);
+}

--- a/vite.config.mock.ts
+++ b/vite.config.mock.ts
@@ -1,0 +1,21 @@
+import { resolve } from "node:path";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react()],
+  root: resolve(__dirname, "src/mock"),
+  publicDir: resolve(__dirname, "public"),
+  resolve: {
+    alias: {
+      "@": resolve(__dirname, "src"),
+    },
+  },
+  server: {
+    host: "localhost",
+    port: 5174,
+  },
+  build: {
+    outDir: resolve(__dirname, "dist-mock"),
+  },
+});


### PR DESCRIPTION
## Summary

- Add a mock mode (`bun run dev:mock`) that runs the full OpenExcel UI at `localhost:5174` without Office.js or LLM backend dependencies
- Mock at the adapter + agent boundary: `MockWorkbookAdapter` (in-memory workbook) + `MockAgentDriver` (JSON fixture replay engine)
- 5 comprehensive scenario fixtures covering all UI states: basic chat, tool calls (success/error/grouping), thinking blocks, streaming/slow responses, and error states (truncation, model errors, image results)
- ScenarioPicker overlay for switching between scenarios at runtime
- 21 Playwright E2E tests validating all scenarios programmatically

## Test plan

- [x] `bun run dev:mock` starts Vite on `http://localhost:5174` (no HTTPS, no Office.js)
- [x] All 21 E2E tests pass: `bun run e2e:mock` (21 passed, 43s)
- [x] TypeScript typecheck clean: `npx tsc --noEmit -p tsconfig.app.json`
- [x] Biome lint clean on all new files
- [x] Production `bun run dev` is completely unaffected

Generated with [Claude Code](https://claude.com/claude-code)